### PR TITLE
Update minimum httpdate version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ sha1 = "0.4.0"
 byteorder = "1.2.1"
 rand = "0.4.2"
 tk-sendfile = { version="0.4.0", optional=true }
-httpdate = { version="0.3.0", optional=true }
+httpdate = { version="0.3.2", optional=true }
 
 [features]
 # TODO(tailhook) remove "sendfile" feature on next major bump


### PR DESCRIPTION
Versions <0.3.2 contain a typo preventing the correct parsing of dates in the month May.